### PR TITLE
Corrected sql db show-usage to list-usages.

### DIFF
--- a/sql-database/monitor-and-scale-database/monitor-and-scale-database.sh
+++ b/sql-database/monitor-and-scale-database/monitor-and-scale-database.sh
@@ -27,7 +27,7 @@ az sql db create \
 	--service-objective S0
 
 # Monitor database size
-az sql db show-usage \
+az sql db list-usages \
 	--name mySampleDatabase \
 	--resource-group myResourceGroup \
 	--name $servername


### PR DESCRIPTION
`show-usage` was the orginal name of the command, but this command was removed before sql command module GA. This command was recently reinstated as `list-usages` https://github.com/Azure/azure-cli/commit/12aafb42835491baaf3a17867786e78553a08699 .