### PR TITLE
Storage refactor: Copy CLI scripts from storage to vm.

### DIFF
--- a/virtual-machine/copy-managed-disks-to-same-or-different-subscription/copy-managed-disks-to-same-or-different-subscription.sh
+++ b/virtual-machine/copy-managed-disks-to-same-or-different-subscription/copy-managed-disks-to-same-or-different-subscription.sh
@@ -1,0 +1,30 @@
+#Provide the subscription Id of the subscription where managed disk exists
+sourceSubscriptionId=dd80b94e-0463-4a65-8d04-c94f403879dc
+
+#Provide the name of your resource group where managed disk exists
+sourceResourceGroupName=mySourceResourceGroupName
+
+#Provide the name of the managed disk
+managedDiskName=myDiskName
+
+#Set the context to the subscription Id where managed disk exists
+az account set --subscription $sourceSubscriptionId
+
+#Get the managed disk Id 
+managedDiskId=$(az disk show --name $managedDiskName --resource-group $sourceResourceGroupName --query [id] -o tsv)
+
+#If managedDiskId is blank then it means that managed disk does not exist.
+echo 'source managed disk Id is: ' $managedDiskId
+
+#Provide the subscription Id of the subscription where managed disk will be copied to
+targetSubscriptionId=6492b1f7-f219-446b-b509-314e17e1efb0
+
+#Name of the resource group where managed disk will be copied to
+targetResourceGroupName=mytargetResourceGroupName
+
+#Set the context to the subscription Id where managed disk will be copied to
+az account set --subscription $targetSubscriptionId
+
+#Copy managed disk to different subscription using managed disk Id
+az disk create --resource-group $targetResourceGroupName --name $managedDiskName --source $managedDiskId
+

--- a/virtual-machine/copy-snapshot-to-same-or-different-subscription/copy-snapshot-to-same-or-different-subscription.sh
+++ b/virtual-machine/copy-snapshot-to-same-or-different-subscription/copy-snapshot-to-same-or-different-subscription.sh
@@ -1,0 +1,32 @@
+#Provide the subscription Id of the subscription where snapshot exists
+sourceSubscriptionId=dd80b94e-0463-4a65-8d04-c94f403879dc
+
+#Provide the name of your resource group where snapshot exists
+sourceResourceGroupName=mySourceResourceGroupName
+
+#Provide the name of the snapshot
+snapshotName=mySnapshotName
+
+#Set the context to the subscription Id where snapshot exists
+az account set --subscription $sourceSubscriptionId
+
+#Get the snapshot Id 
+snapshotId=$(az snapshot show --name $snapshotName --resource-group $sourceResourceGroupName --query [id] -o tsv)
+
+#If snapshotId is blank then it means that snapshot does not exist.
+echo 'source snapshot Id is: ' $snapshotId
+
+#Provide the subscription Id of the subscription where snapshot will be copied to
+#If snapshot is copied to the same subscription then you can skip this step
+targetSubscriptionId=6492b1f7-f219-446b-b509-314e17e1efb0
+
+#Name of the resource group where snapshot will be copied to
+targetResourceGroupName=mytargetResourceGroupName
+
+#Set the context to the subscription Id where snapshot will be copied to
+#If snapshot is copied to the same subscription then you can skip this step
+az account set --subscription $targetSubscriptionId
+
+#Copy snapshot to different subscription using the snapshot Id
+az snapshot create --resource-group $targetResourceGroupName --name $snapshotName --source $snapshotId
+

--- a/virtual-machine/copy-snapshots-to-storage-account/copy-snapshots-to-storage-account.sh
+++ b/virtual-machine/copy-snapshots-to-storage-account/copy-snapshots-to-storage-account.sh
@@ -1,0 +1,35 @@
+#Provide the subscription Id where snapshot is created
+subscriptionId=dd80b94e-0463-4a65-8d04-c94f403879dc
+
+#Provide the name of your resource group where snapshot is created
+resourceGroupName=myResourceGroupName
+
+#Provide the snapshot name 
+snapshotName=mySnapshotName
+
+#Provide Shared Access Signature (SAS) expiry duration in seconds e.g. 3600.
+#Know more about SAS here: https://docs.microsoft.com/en-us/azure/storage/storage-dotnet-shared-access-signature-part-1
+sasExpiryDuration=3600
+
+#Provide storage account name where you want to copy the snapshot. 
+storageAccountName=mystorageaccountname
+
+#Name of the storage container where the downloaded snapshot will be stored
+storageContainerName=mystoragecontainername
+
+#Provide the key of the storage account where you want to copy snapshot. 
+storageAccountKey=mystorageaccountkey
+
+#Provide the name of the VHD file to which snapshot will be copied.
+destinationVHDFileName=myvhdfilename
+
+az account set --subscription $subscriptionId
+
+sas=$(az snapshot grant-access --resource-group $resourceGroupName --name $snapshotName --duration-in-seconds $sasExpiryDuration --query [accessSas] -o tsv)
+
+az storage blob copy start --destination-blob $destinationVHDFileName --destination-container $storageContainerName --account-name $storageAccountName --account-key $storageAccountKey --source-uri $sas
+
+
+
+
+

--- a/virtual-machine/create-managed-data-disks-from-vhd/create-managed-data-disks-from-vhd.sh
+++ b/virtual-machine/create-managed-data-disks-from-vhd/create-managed-data-disks-from-vhd.sh
@@ -1,0 +1,35 @@
+#Provide the subscription Id
+subscriptionId=mySubscriptionId
+
+#Provide the name of your resource group.
+#Ensure that resource group is already created 
+resourceGroupName=myResourceGroupName
+
+#Provide the name of the Managed Disk
+diskName=myDiskName
+
+#Provide the size of the disks in GB. It should be greater than the VHD file size.
+diskSize=128
+
+
+#Provide the URI of the VHD file that will be used to create Managed Disk. 
+# VHD file can be deleted as soon as Managed Disk is created.
+# e.g. https://contosostorageaccount1.blob.core.windows.net/vhds/contosovhd123.vhd 
+vhdUri=https://contosostorageaccount1.blob.core.windows.net/vhds/contosoumd78620170425131836.vhd
+
+#Provide the storage type for the Managed Disk. Premium_LRS or Standard_LRS.
+storageType=Premium_LRS
+
+
+#Provide the Azure location (e.g. westus) where Managed Disk will be located. 
+#The location should be same as the location of the storage account where VHD file is stored.
+#Get all the Azure location supported for your subscription using command below:
+#az account list-locations
+location=westus
+
+#Set the context to the subscription Id where Managed Disk will be created
+az account set --subscription $subscriptionId
+
+#Create the Managed disk from the VHD file 
+az disk create --resource-group $resourceGroupName --name $diskName --sku $storageType --location $location --size-gb $diskSize --source $vhdUri
+

--- a/virtual-machine/create-managed-disks-from-snapshot/create-managed-disks-from-snapshot.sh
+++ b/virtual-machine/create-managed-disks-from-snapshot/create-managed-disks-from-snapshot.sh
@@ -1,0 +1,29 @@
+#Provide the subscription Id of the subscription where you want to create Managed Disks
+subscriptionId=dd80b94e-0463-4a65-8d04-c94f403879dc
+
+#Provide the name of your resource group
+resourceGroupName=myResourceGroupName
+
+#Provide the name of the snapshot that will be used to create Managed Disks
+snapshotName=mySnapshotName
+
+#Provide the name of the new Managed Disks that will be create
+diskName=myDiskName
+
+#Provide the size of the disks in GB. It should be greater than the VHD file size.
+diskSize=128
+
+#Provide the storage type for Managed Disk. Premium_LRS or Standard_LRS.
+storageType=Premium_LRS
+
+#Set the context to the subscription Id where Managed Disk will be created
+az account set --subscription $subscriptionId
+
+#Get the snapshot Id 
+snapshotId=$(az snapshot show --name $snapshotName --resource-group $resourceGroupName --query [id] -o tsv)
+
+#Create a new Managed Disks using the snapshot Id
+#Note that managed disk will be created in the same location as the snapshot
+az disk create --resource-group $resourceGroupName --name $diskName --sku $storageType --size-gb $diskSize --source $snapshotId
+
+


### PR DESCRIPTION
As part of the storage refactor, I copied the following cli-python samplevfolders that each contained one script file, from /storage to storage/vm:

- copy-managed-disks-to-same-or-different-subscription
- copy-snapshot-to-same-or-different-subscription
- copy-snapshots-to-storage-account
- create-managed-data-disks-from-vhd
- create-managed-disks-from-snapshot

@robinsh @cwatson-cat 