### PR TITLE
Fix: add UTC flag to date command in SQL restore sample script

### DIFF
--- a/sql-database/restore-database/restore-database.sh
+++ b/sql-database/restore-database/restore-database.sh
@@ -38,7 +38,7 @@ sleep 30m
 # restorePoint=“2021-07-09T13:10:00Z”
 restorePoint=$(date +%s)
 restorePoint=$(expr $restorePoint - 60)
-restorePoint=$(date -d @$restorePoint +"%Y-%m-%dT%T")
+restorePoint=$(date -u -d @$restorePoint +"%Y-%m-%dT%T")
 echo $restorePoint
 
 echo "Restoring to $restoreServer"


### PR DESCRIPTION
## Summary

GitHub issue #550 reported that the restore-database.sh sample does not output UTC time when formatting the restore point timestamp. Without the `-u` flag, the `date` command formats in local timezone, causing incorrect restore point values when passed to `az sql db restore --time` (which expects UTC).

## Changes

- **sql-database/restore-database/restore-database.sh** — Added `-u` flag to the `date` command so the restore point timestamp is formatted in UTC regardless of the host system's timezone setting.

## Testing

- [ ] Build passes
- [ ] Manually verified

## Related work items

[AB#607270](https://dev.azure.com/msft-skilling/Content/_workitems/edit/607270) — Fix: Add UTC flag to date command in SQL restore sample script

Fixes https://github.com/Azure-Samples/azure-cli-samples/issues/550